### PR TITLE
Remove conflict with use of Debug and Display

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -177,6 +177,7 @@ version = "0.2.1"
 dependencies = [
  "proc-macro2",
  "pyo3",
+ "pyo3_special_method_derive_lib",
  "quote",
  "quote_into",
  "syn 2.0.66",
@@ -202,6 +203,10 @@ dependencies = [
  "pyo3",
  "pyo3_special_method_derive 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "pyo3_special_method_derive_lib"
+version = "0.2.1"
 
 [[package]]
 name = "quote"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -174,18 +174,6 @@ dependencies = [
 [[package]]
 name = "pyo3_special_method_derive"
 version = "0.2.1"
-dependencies = [
- "proc-macro2",
- "pyo3",
- "pyo3_special_method_derive_lib",
- "quote",
- "quote_into",
- "syn 2.0.66",
-]
-
-[[package]]
-name = "pyo3_special_method_derive"
-version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e831c9f620de245243f105f2d764c59c32a853bd1c9fb34504116e0d6d094fad"
 dependencies = [
@@ -197,16 +185,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "pyo3_special_method_derive"
+version = "0.2.2"
+dependencies = [
+ "proc-macro2",
+ "pyo3",
+ "pyo3_special_method_derive_lib",
+ "quote",
+ "quote_into",
+ "syn 2.0.66",
+]
+
+[[package]]
 name = "pyo3_special_method_derive_example"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "pyo3",
- "pyo3_special_method_derive 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pyo3_special_method_derive 0.2.1",
 ]
 
 [[package]]
 name = "pyo3_special_method_derive_lib"
-version = "0.2.1"
+version = "0.2.2"
 
 [[package]]
 name = "quote"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
     "pyo3_special_method_derive_core",
     "pyo3_special_method_derive_example",
+    "pyo3_special_method_derive_lib"
 ]
 resolver = "2"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 description = "Automatically derive Python dunder methods for your Rust code"
 license = "MIT"

--- a/pyo3_special_method_derive_core/Cargo.toml
+++ b/pyo3_special_method_derive_core/Cargo.toml
@@ -12,6 +12,6 @@ quote = "1.0"
 proc-macro2 = "1.0"
 quote_into = "0.2.0"
 pyo3 = { version = "0.21", features = ["multiple-pymethods"] }
-
+pyo3_special_method_derive_lib = { path = "../pyo3_special_method_derive_lib" }
 [lib]
 proc-macro = true

--- a/pyo3_special_method_derive_core/src/lib.rs
+++ b/pyo3_special_method_derive_core/src/lib.rs
@@ -1,4 +1,7 @@
 //! Derive macros to help with Rust PyO3 support.
+//! 
+//! Please see [these docs](https://docs.rs/pyo3_special_method_derive/0.2.1/pyo3_special_method_derive_lib/) for the PyDisplay and PyDebug 
+//! traits which power `Str` and `Repr`.
 //!
 //! This crate automatically derives the following functions for structs and enums:
 //! - `__str__`
@@ -219,8 +222,9 @@ pub fn dir_derive(input: TokenStream) -> TokenStream {
 
 /// Add a `__str__` method to the struct or enum.
 ///
-/// Important note: This implements the Display trait so any conflicting implementations
-/// should be removed to use this. Additionally, all internal types should implement [`Debug`].
+/// This expects every type for which its field or variant is not skipped to implement the PyDisplay trait.
+/// Certain implementations are automatically provided, but you can implement the required trait yourself
+/// or use a provided convenience macro.
 ///
 /// - Skip printing of certain fields by adding the `#[pyo3_smd(skip)]` attribute macro
 /// - To specialze skipping for `__str__`, use the `#[pyo3_smd_str(skip)]` attributes
@@ -265,8 +269,9 @@ pub fn str_derive(input_stream: TokenStream) -> TokenStream {
 
 /// Add a `__repr__` method to the struct or enum.
 ///
-/// Important note: This implements the [`Debug`] trait so any conflicting implementations
-/// should be removed to use this.
+/// This expects every type for which its field or variant is not skipped to implement the PyDebug trait.
+/// Certain implementations are automatically provided, but you can implement the required trait yourself
+/// or use a provided convenience macro.
 ///
 /// - Skip printing of certain fields by adding the `#[pyo3_smd(skip)]` attribute macro
 /// - To specialze skipping for `__repr__`, use the `#[pyo3_smd_repr(skip)]` attributes

--- a/pyo3_special_method_derive_core/src/lib.rs
+++ b/pyo3_special_method_derive_core/src/lib.rs
@@ -254,7 +254,8 @@ pub fn str_derive(input_stream: TokenStream) -> TokenStream {
         #[pyo3::pymethods]
         impl #name {
             pub fn __str__(&self) -> String {
-                format!("{self}")
+                use pyo3_special_method_derive_lib::PyDisplay;
+                format!("{}", <Self as PyDisplay>::fmt_display(self))
             }
         }
     };
@@ -299,7 +300,8 @@ pub fn repr_derive(input_stream: TokenStream) -> TokenStream {
         #[pyo3::pymethods]
         impl #name {
             pub fn __repr__(&self) -> String {
-                format!("{self:?}")
+                use pyo3_special_method_derive_lib::PyDebug;
+                format!("{}", <Self as PyDebug>::fmt_debug(self))
             }
         }
     };

--- a/pyo3_special_method_derive_core/src/lib.rs
+++ b/pyo3_special_method_derive_core/src/lib.rs
@@ -1,6 +1,6 @@
 //! Derive macros to help with Rust PyO3 support.
 //! 
-//! Please see [these docs](https://docs.rs/pyo3_special_method_derive/0.2.1/pyo3_special_method_derive_lib/) for the PyDisplay and PyDebug 
+//! Please see [these docs](https://docs.rs/pyo3_special_method_derive/0.2.2/pyo3_special_method_derive_lib/) for the PyDisplay and PyDebug 
 //! traits which power `Str` and `Repr`.
 //!
 //! This crate automatically derives the following functions for structs and enums:

--- a/pyo3_special_method_derive_core/src/lib.rs
+++ b/pyo3_special_method_derive_core/src/lib.rs
@@ -1,6 +1,6 @@
 //! Derive macros to help with Rust PyO3 support.
-//! 
-//! Please see [these docs](https://docs.rs/pyo3_special_method_derive/0.2.2/pyo3_special_method_derive_lib/) for the PyDisplay and PyDebug 
+//!
+//! Please see [these docs](https://docs.rs/pyo3_special_method_derive/0.2.2/pyo3_special_method_derive_lib/) for the PyDisplay and PyDebug
 //! traits which power `Str` and `Repr`.
 //!
 //! This crate automatically derives the following functions for structs and enums:

--- a/pyo3_special_method_derive_example/debugging.py
+++ b/pyo3_special_method_derive_example/debugging.py
@@ -7,6 +7,7 @@ Set breakpoints for debugging, or simply run this program!
 
 import pyo3_smd_example
 
-person = pyo3_smd_example.Person()
+person = pyo3_smd_example.Person.new_dummy()
 
+# Put a breakpoint here
 print(person)

--- a/pyo3_special_method_derive_example/src/lib.rs
+++ b/pyo3_special_method_derive_example/src/lib.rs
@@ -29,7 +29,7 @@ pub struct Person {
 
 #[pymethods]
 impl Person {
-    #[new]
+    #[staticmethod]
     pub fn new_dummy() -> Self {
         Self {
             name: "Name here".to_string(),
@@ -39,6 +39,26 @@ impl Person {
                 city: "City here".to_string(),
                 street: "Street here".to_string(),
                 street_number: u32::MAX,
+            },
+        }
+    }
+    #[new]
+    pub fn new(
+        name: String,
+        age: u8,
+        country: String,
+        city: String,
+        street: String,
+        street_number: u32,
+    ) -> Self {
+        Self {
+            name,
+            age,
+            address: Address::House {
+                country,
+                city,
+                street,
+                street_number,
             },
         }
     }

--- a/pyo3_special_method_derive_example/testing.py
+++ b/pyo3_special_method_derive_example/testing.py
@@ -7,18 +7,36 @@ Set breakpoints for debugging, or simply run this program!
 
 import pyo3_smd_example
 
-person = pyo3_smd_example.Person()
-# Person(name="Name here", age=0, address=Address.House(country="Country here", city="City here", street="Street here", street_number=4294967295))
-print(person)
-# person.__dict__={'address': Address.House(country="Country here", city="City here", street="Street here", street_number=4294967295), 'name': 'Name here', 'age': 0}
-print(f"{person.__dict__=}")
-# person.address.__dict__={'city': 'City here', 'country': 'Country here', 'street': 'Street here', 'street_number': 4294967295}
-print(f"{person.address.__dict__=}")
-# person.name='Name here'
-print(f"{person.name=}")
-# person.address.country='Country here'
-print(f"{person.address.country=}")
-# dir(person)=['address', 'age', 'name']
-print(f"{dir(person)=}")
-# dir(person.address)=['city', 'country', 'street', 'street_number']
-print(f"{dir(person.address)=}")
+person = pyo3_smd_example.Person(
+    name="Name here",
+    age=0,
+    country="Country here",
+    city="City here",
+    street="Street here",
+    street_number=4294967295,
+)
+
+assert (
+    str(person)
+    == 'Person(name="Name here", age=0, address=Address.House(country="Country here", city="City here", street="Street here", street_number=4294967295))'
+)
+
+assert (
+    str(person.__dict__)
+    == "{'address': Address.House(country=\"Country here\", city=\"City here\", street=\"Street here\", street_number=4294967295), 'name': 'Name here', 'age': 0}"
+)
+
+assert person.address.__dict__ == {
+    "city": "City here",
+    "country": "Country here",
+    "street": "Street here",
+    "street_number": 4294967295,
+}
+
+assert person.name == "Name here"
+
+assert person.address.country == "Country here"
+
+assert dir(person) == ["address", "age", "name"]
+
+assert dir(person.address) == ["city", "country", "street", "street_number"]

--- a/pyo3_special_method_derive_lib/Cargo.toml
+++ b/pyo3_special_method_derive_lib/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "pyo3_special_method_derive_lib"
+version.workspace = true
+edition.workspace = true
+description.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]

--- a/pyo3_special_method_derive_lib/src/lib.rs
+++ b/pyo3_special_method_derive_lib/src/lib.rs
@@ -1,0 +1,46 @@
+pub trait PyDebug {
+    fn fmt_debug(&self) -> String;
+}
+
+impl<T: PyDebug> PyDebug for Option<T> {
+    fn fmt_debug(&self) -> String {
+        match self {
+            Some(x) => x.fmt_debug(),
+            None => "None".to_string(),
+        }
+    }
+}
+
+pub trait PyDisplay {
+    fn fmt_display(&self) -> String;
+}
+
+impl<T: PyDisplay> PyDisplay for Option<T> {
+    fn fmt_display(&self) -> String {
+        match self {
+            Some(x) => x.fmt_display(),
+            None => "None".to_string(),
+        }
+    }
+}
+
+macro_rules! pydebug_pydisplay {
+    ($t:ty) => {
+        impl PyDebug for $t {
+            fn fmt_debug(&self) -> String {
+                format!("{self:?}")
+            }
+        }
+        impl PyDisplay for $t {
+            fn fmt_display(&self) -> String {
+                format!("{self:?}")
+                // NOTE: Do not use the Display impl.
+                // format!("{self}")
+            }
+        }
+    };
+}
+
+pydebug_pydisplay!(u32);
+pydebug_pydisplay!(f32);
+pydebug_pydisplay!(String);

--- a/pyo3_special_method_derive_lib/src/lib.rs
+++ b/pyo3_special_method_derive_lib/src/lib.rs
@@ -1,29 +1,24 @@
+//! This crate exports 2 traits which should be implemented for
+//! every type for which its field or variant is not skipped.
+//!
+//! It also exports a macro to use the Debug and Display traits to generate a PyDebug and PyDisplay
+//! implementation.
+
+/// Types which can be displayed into the `__repr__` implementation.
 pub trait PyDebug {
     fn fmt_debug(&self) -> String;
 }
 
-impl<T: PyDebug> PyDebug for Option<T> {
-    fn fmt_debug(&self) -> String {
-        match self {
-            Some(x) => x.fmt_debug(),
-            None => "None".to_string(),
-        }
-    }
-}
-
+/// Types which can be displayed into the `__str__` implementation.
 pub trait PyDisplay {
     fn fmt_display(&self) -> String;
 }
 
-impl<T: PyDisplay> PyDisplay for Option<T> {
-    fn fmt_display(&self) -> String {
-        match self {
-            Some(x) => x.fmt_display(),
-            None => "None".to_string(),
-        }
-    }
-}
-
+/// Use this trait to automatically derive PyDebug and PyDisplay for your type.
+/// It uses the Debug and Display traits internally. Because this usage can expose
+/// Rust semantics, types, or otherwise look foreign, this should only be used for types which
+/// are simple enough to not be distinctly Rust-y.
+#[macro_export]
 macro_rules! pydebug_pydisplay {
     ($t:ty) => {
         impl PyDebug for $t {
@@ -41,6 +36,63 @@ macro_rules! pydebug_pydisplay {
     };
 }
 
+pydebug_pydisplay!(u8);
+pydebug_pydisplay!(u16);
 pydebug_pydisplay!(u32);
+pydebug_pydisplay!(u64);
+pydebug_pydisplay!(u128);
+
+pydebug_pydisplay!(i8);
+pydebug_pydisplay!(i16);
+pydebug_pydisplay!(i32);
+pydebug_pydisplay!(i64);
+pydebug_pydisplay!(i128);
+
 pydebug_pydisplay!(f32);
+pydebug_pydisplay!(f64);
+
+pydebug_pydisplay!(bool);
+
 pydebug_pydisplay!(String);
+pydebug_pydisplay!(&str);
+
+impl<T: PyDebug> PyDebug for &[T] {
+    fn fmt_debug(&self) -> String {
+        format!(
+            "[{}]",
+            self.iter()
+                .map(|x| x.fmt_debug())
+                .collect::<Vec<_>>()
+                .join(",")
+        )
+    }
+}
+impl<T: PyDisplay> PyDisplay for &[T] {
+    fn fmt_display(&self) -> String {
+        format!(
+            "[{}]",
+            self.iter()
+                .map(|x| x.fmt_display())
+                .collect::<Vec<_>>()
+                .join(",")
+        )
+    }
+}
+
+impl<T: PyDebug> PyDebug for Option<T> {
+    fn fmt_debug(&self) -> String {
+        match self {
+            Some(x) => x.fmt_debug(),
+            None => "None".to_string(),
+        }
+    }
+}
+
+impl<T: PyDisplay> PyDisplay for Option<T> {
+    fn fmt_display(&self) -> String {
+        match self {
+            Some(x) => x.fmt_display(),
+            None => "None".to_string(),
+        }
+    }
+}


### PR DESCRIPTION
Refs #24.

This PR implements a deconfliction of Debug and Display. The only weakness is that we trade generic usage for customization and specificity. Basically, it introduces `PyDebug` and `PyDisplay` traits which can be implemented for custom types (although impls are provided for common stdlib traits).